### PR TITLE
added profile entity and privilege level

### DIFF
--- a/prisma/migrations/20220129213723_added_profile/migration.sql
+++ b/prisma/migrations/20220129213723_added_profile/migration.sql
@@ -1,0 +1,14 @@
+-- CreateEnum
+CREATE TYPE "PrivilegeLevel" AS ENUM ('PROFILE', 'ADMIN');
+
+-- CreateTable
+CREATE TABLE "Profile" (
+    "id" SERIAL NOT NULL,
+    "email" TEXT NOT NULL,
+    "privilegeLevel" "PrivilegeLevel" NOT NULL DEFAULT E'PROFILE',
+
+    CONSTRAINT "Profile_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Profile_email_key" ON "Profile"("email");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,6 +11,17 @@ datasource db {
 }
 
 model Category {
-  id    Int    @id @default(autoincrement())
-  name  String
+  id   Int    @id @default(autoincrement())
+  name String
+}
+
+model Profile {
+  id             Int            @id @default(autoincrement())
+  email          String         @unique
+  privilegeLevel PrivilegeLevel @default(PROFILE)
+}
+
+enum PrivilegeLevel {
+  PROFILE
+  ADMIN
 }


### PR DESCRIPTION
- Created a profile entity in the schema with fields: email, id, and privilegeLevel
- Created an enum for privilegeLevel
- Created a migration for new entity created

Creating the profile entity allows us to distinguish between admins and regular users (profiles) and we can store people's information in our database.

Tested: Ran prisma studio and added a test user with an email. Created another user with the same email to verify that error was thrown upon creation.